### PR TITLE
Fix to bit shift errors

### DIFF
--- a/block_group_descriptor.go
+++ b/block_group_descriptor.go
@@ -119,7 +119,7 @@ func (bgd *BlockGroupDescriptor) IsInodeTableZeroed() bool {
 // InodeTableBlock returns the absolute block number of the inode-table.
 func (bgd *BlockGroupDescriptor) InodeTableBlock() uint64 {
 	if bgd.sb.Is64Bit() == true {
-		return uint64(bgd.data.BgInodeTableHi<<32) | uint64(bgd.data.BgInodeTableLo)
+		return (uint64(bgd.data.BgInodeTableHi) << 32) | uint64(bgd.data.BgInodeTableLo)
 	} else {
 		return uint64(bgd.data.BgInodeTableLo)
 	}
@@ -127,7 +127,7 @@ func (bgd *BlockGroupDescriptor) InodeTableBlock() uint64 {
 
 func (bgd *BlockGroupDescriptor) InodeBitmapBlock() uint64 {
 	if bgd.sb.Is64Bit() == true {
-		return uint64(bgd.data.BgInodeBitmapHi<<32) | uint64(bgd.data.BgInodeBitmapLo)
+		return (uint64(bgd.data.BgInodeBitmapHi) << 32) | uint64(bgd.data.BgInodeBitmapLo)
 	} else {
 		return uint64(bgd.data.BgInodeBitmapLo)
 	}

--- a/extent.go
+++ b/extent.go
@@ -37,7 +37,7 @@ type ExtentIndexNode struct {
 }
 
 func (ein *ExtentIndexNode) LeafPhysicalBlock() uint64 {
-	return uint64(ein.EiLeafPhysicalBlockHi<<32) | uint64(ein.EiLeafPhysicalBlockLo)
+	return (uint64(ein.EiLeafPhysicalBlockHi) << 32) | uint64(ein.EiLeafPhysicalBlockLo)
 }
 
 func (ein *ExtentIndexNode) String() string {
@@ -52,7 +52,7 @@ type ExtentLeafNode struct {
 }
 
 func (eln *ExtentLeafNode) StartPhysicalBlock() uint64 {
-	return uint64(eln.EeStartPhysicalBlockHi<<32) | uint64(eln.EeStartPhysicalBlockLo)
+	return (uint64(eln.EeStartPhysicalBlockHi) << 32) | uint64(eln.EeStartPhysicalBlockLo)
 }
 
 func (eln *ExtentLeafNode) String() string {

--- a/superblock.go
+++ b/superblock.go
@@ -405,7 +405,7 @@ func (sb *Superblock) ReadPhysicalBlock(absoluteBlockNumber uint64, length uint6
 
 func (sb *Superblock) BlockCount() uint64 {
 	if sb.is64Bit == true {
-		return uint64(sb.data.SBlocksCountHi<<32) | uint64(sb.data.SBlocksCountLo)
+		return (uint64(sb.data.SBlocksCountHi) << 32) | uint64(sb.data.SBlocksCountLo)
 	} else {
 		return uint64(sb.data.SBlocksCountLo)
 	}


### PR DESCRIPTION
As corrected in this PR, at many instances in the code a 32-bit or 16-bit number was being left shifted by 32. The numeric values were too small for that to be a valid shift.

I have just moved the shifts outside of the `uint64` cast which should fix this issue.